### PR TITLE
Preset blend time defaults to 0

### DIFF
--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -139,7 +139,7 @@ export default class Visualizer {
     this.audio.disconnectAudio(audioNode);
   }
 
-  loadPreset (presetMap, blendTime) {
+  loadPreset (presetMap, blendTime = 0) {
     const preset = Object.assign({}, presetMap);
     preset.baseVals = Object.assign({}, this.baseValsDefaults, preset.baseVals);
     for (let i = 0; i < preset.shapes.length; i++) {


### PR DESCRIPTION
Just a nitpick. Personally, I don't blend presets, I create a new visualizer instance for each preset since I have integrated Butterchurn alongside some unrelated 2d and webgl visualizations and can cycle between them all.

Great work on this project, by the way!