### PR TITLE
Pixel ratio defaults to device pixel ratio

### DIFF
--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -38,7 +38,7 @@ export default class Renderer {
     this.height = opts.height || 900;
     this.mesh_width = opts.meshWidth || 48;
     this.mesh_height = opts.meshHeight || 36;
-    this.pixelRatio = opts.pixelRatio || 1;
+    this.pixelRatio = opts.pixelRatio || window.devicePixelRatio || 1;
     this.textureRatio = opts.textureRatio || 1;
     this.outputFXAA = opts.outputFXAA || false;
     this.texsizeX = this.width * this.pixelRatio * this.textureRatio;


### PR DESCRIPTION
This seems sensible and results in one less option to pass to ````createVisualizer()````.