### PR TITLE
Correct Sample Size + Remove Pre-FFT Time Smoothing + Optimisations

### DIFF
--- a/src/audio/audioLevels.js
+++ b/src/audio/audioLevels.js
@@ -12,7 +12,7 @@ export default class AudioLevels {
 
     this.att.fill(1);
     this.avg.fill(1);
-    this.longAve.fill(1);
+    this.longAvg.fill(1);
   }
   /* eslint-disable camelcase */
   get bass () {

--- a/src/audio/audioLevels.js
+++ b/src/audio/audioLevels.js
@@ -1,26 +1,35 @@
 export default class AudioLevels {
   constructor (audio) {
     this.audio = audio;
+    this.starts = new Uint8Array([0, 85, 170]);
+    this.stops = new Uint8Array([85, 170, 255]);
 
-    this.bass = 1;
-    this.bass_att = 1;
-    this.bass_imm = 0;
-    this.bass_avg = 1;
-    this.bass_long_avg = 1;
-
-    this.mid = 1;
-    this.mid_att = 1;
-    this.mid_imm = 0;
-    this.mid_avg = 1;
-    this.mid_long_avg = 1;
-
-    this.treb = 1;
-    this.treb_att = 1;
-    this.treb_imm = 0;
-    this.treb_avg = 1;
-    this.treb_long_avg = 1;
+    this.val = new Float32Array(3);
+    this.att = new Float32Array(3);
+    this.imm = new Float32Array(3);
+    this.avg = new Float32Array(3);
+    this.longAvg = new Float32Array(3);
   }
-
+  /* eslint-disable camelcase */
+  get bass () {
+    return this.val[0];
+  }
+  get bass_att () {
+    return this.att[0];
+  }
+  get mid () {
+    return this.val[1];
+  }
+  get mid_att () {
+    return this.att[1];
+  }
+  get treb () {
+    return this.val[2];
+  }
+  get treb_att () {
+    return this.att[2];
+  }
+  /* eslint-enable camelcase */
   static isFiniteNumber (num) {
     return (Number.isFinite(num) && !Number.isNaN(num));
   }
@@ -41,28 +50,23 @@ export default class AudioLevels {
         effectiveFPS = 120;
       }
 
-      const val = [0.0, 0.0, 0.0];
-      const imm = [0.0, 0.0, 0.0];
+      // Clear for next loop
+      this.imm.fill(0);
       for (let i = 0; i < 3; i++) {
-        const start = Math.floor(this.audio.numSamps * (i / 6));
-        const end = Math.floor(this.audio.numSamps * ((i + 1) / 6));
-        for (let j = start; j < end; j++) {
-          imm[i] += this.audio.freqArray[j];
+        for (let j = this.starts[i]; j < this.stops[i]; j++) {
+          this.imm[i] += this.audio.freqArray[j];
         }
       }
 
-      const att = [this.bass_att, this.mid_att, this.treb_att];
-      const avg = [this.bass_avg, this.mid_avg, this.treb_avg];
-      const longAvg = [this.bass_long_avg, this.mid_long_avg, this.treb_long_avg];
       for (let i = 0; i < 3; i++) {
         let rate;
-        if (imm[i] > avg[i]) {
+        if (this.imm[i] > this.avg[i]) {
           rate = 0.2;
         } else {
           rate = 0.5;
         }
         rate = AudioLevels.adjustRateToFPS(rate, 30.0, effectiveFPS);
-        avg[i] = (avg[i] * rate) + (imm[i] * (1 - rate));
+        this.avg[i] = (this.avg[i] * rate) + (this.imm[i] * (1 - rate));
 
         if (frame < 50) {
           rate = 0.9;
@@ -70,36 +74,16 @@ export default class AudioLevels {
           rate = 0.992;
         }
         rate = AudioLevels.adjustRateToFPS(rate, 30.0, effectiveFPS);
-        longAvg[i] = (longAvg[i] * rate) + (imm[i] * (1 - rate));
+        this.longAvg[i] = (this.longAvg[i] * rate) + (this.imm[i] * (1 - rate));
 
-        if (Math.abs(longAvg[i]) < 0.001) {
-          val[i] = 1.0;
-          att[i] = 1.0;
+        if (Math.abs(this.longAvg[i]) < 0.001) {
+          this.val[i] = 1.0;
+          this.att[i] = 1.0;
         } else {
-          val[i] = imm[i] / longAvg[i];
-          att[i] = avg[i] / longAvg[i];
+          this.val[i] = this.imm[i] / this.longAvg[i];
+          this.att[i] = this.avg[i] / this.longAvg[i];
         }
       }
-
-      this.bass = val[0];
-      this.mid = val[1];
-      this.treb = val[2];
-
-      this.bass_att = att[0];
-      this.mid_att = att[1];
-      this.treb_att = att[2];
-
-      this.bass_imm = imm[0];
-      this.mid_imm = imm[1];
-      this.treb_imm = imm[2];
-
-      this.bass_avg = avg[0];
-      this.mid_avg = avg[1];
-      this.treb_avg = avg[2];
-
-      this.bass_long_avg = longAvg[0];
-      this.mid_long_avg = longAvg[1];
-      this.treb_long_avg = longAvg[2];
     }
   }
 }

--- a/src/audio/audioLevels.js
+++ b/src/audio/audioLevels.js
@@ -5,10 +5,14 @@ export default class AudioLevels {
     this.stops = new Uint8Array([85, 170, 255]);
 
     this.val = new Float32Array(3);
-    this.att = new Float32Array(3);
     this.imm = new Float32Array(3);
+    this.att = new Float32Array(3);
     this.avg = new Float32Array(3);
     this.longAvg = new Float32Array(3);
+
+    this.att.fill(1);
+    this.avg.fill(1);
+    this.longAve.fill(1);
   }
   /* eslint-disable camelcase */
   get bass () {

--- a/src/audio/audioProcessor.js
+++ b/src/audio/audioProcessor.js
@@ -3,8 +3,9 @@ import FFT from './fft';
 export default class AudioProcessor {
   constructor (context) {
     this.numSamps = 512;
+    this.fftSize = this.numSamps * 2;
 
-    this.fft = new FFT(this.numSamps, 512);
+    this.fft = new FFT(this.fftSize, 512);
 
     if (context) {
       this.audioContext = context;
@@ -12,58 +13,73 @@ export default class AudioProcessor {
 
       this.analyser = context.createAnalyser();
       this.analyser.smoothingTimeConstant = 0.0;
-      this.analyser.fftSize = this.numSamps * 2;
+      this.analyser.fftSize = this.fftSize;
 
       this.audible.connect(this.analyser);
 
       // Split channels
       this.analyserL = context.createAnalyser();
       this.analyserL.smoothingTimeConstant = 0.0;
-      this.analyserL.fftSize = this.numSamps * 2;
+      this.analyserL.fftSize = this.fftSize;
 
       this.analyserR = context.createAnalyser();
       this.analyserR.smoothingTimeConstant = 0.0;
-      this.analyserR.fftSize = this.numSamps * 2;
+      this.analyserR.fftSize = this.fftSize;
 
       this.splitter = context.createChannelSplitter(2);
 
       this.audible.connect(this.splitter);
       this.splitter.connect(this.analyserL, 0);
       this.splitter.connect(this.analyserR, 1);
+
+      // New Stuff
+      this.timeByteArray = new Uint8Array(this.fftSize);
+      this.timeByteArrayL = new Uint8Array(this.fftSize);
+      this.timeByteArrayR = new Uint8Array(this.fftSize);
+
+      this.timeArray = new Int8Array(this.fftSize);
+      this.timeByteArraySignedL = new Int8Array(this.fftSize);
+      this.timeByteArraySignedR = new Int8Array(this.fftSize);
+
+
+      this.timeArrayL = new Int8Array(this.numSamps);
+      this.timeArrayR = new Int8Array(this.numSamps);
     }
   }
 
   sampleAudio () {
-    const timeByteArray = new Uint8Array(this.numSamps);
-    const timeByteArrayL = new Uint8Array(this.numSamps);
-    const timeByteArrayR = new Uint8Array(this.numSamps);
-    this.analyser.getByteTimeDomainData(timeByteArray);
-    this.analyserL.getByteTimeDomainData(timeByteArrayL);
-    this.analyserR.getByteTimeDomainData(timeByteArrayR);
+    this.analyser.getByteTimeDomainData(this.timeByteArray);
+    this.analyserL.getByteTimeDomainData(this.timeByteArrayL);
+    this.analyserR.getByteTimeDomainData(this.timeByteArrayR);
 
-    this.updateAudio(timeByteArray, timeByteArrayL, timeByteArrayR);
+    this.updateAudio();
   }
 
-  updateAudio (timeByteArray, timeByteArrayL, timeByteArrayR) {
-    this.timeArray = [];
-    this.timeArrayL = [];
-    this.timeArrayR = [];
-    const tempTimeL = [];
-    const tempTimeR = [];
-    let lastIdx = 0;
-    for (let i = 0; i < this.numSamps; i++) {
-      this.timeArray.push(timeByteArray[i] - 128);
-      this.timeArrayL.push(timeByteArrayL[i] - 128);
-      this.timeArrayR.push(timeByteArrayR[i] - 128);
+  updateAudio () {
+    // let lastIdx = 0;
+    for (let i = 0, j=0; i < this.fftSize; i++) {
+      // Unsigned to Signed
+      this.timeArray[i] = this.timeByteArray[i] - 128;
+      this.timeByteArraySignedL[i] = this.timeByteArrayL[i] - 128;
+      this.timeByteArraySignedR[i] = this.timeByteArrayR[i] - 128;
 
-      tempTimeL[i] = 0.5 * (this.timeArrayL[i] + this.timeArrayL[lastIdx]);
-      tempTimeR[i] = 0.5 * (this.timeArrayR[i] + this.timeArrayR[lastIdx]);
-      lastIdx = i;
+      // Undersampled
+      if (i & 2) { // Equivalent to i % 2
+        this.timeArrayL[j] = this.timeByteArraySignedL[i];
+        this.timeArrayR[j] = this.timeByteArraySignedR[i];
+        j++;
+      }
+
+      // Test no smoothing
+      // tempTimeL[i] = 0.5 * (this.timeArrayL[i] + this.timeArrayL[lastIdx]);
+      // tempTimeR[i] = 0.5 * (this.timeArrayR[i] + this.timeArrayR[lastIdx]);
+      // lastIdx = i;
     }
 
+    // Use full width samples for the FFT
     this.freqArray = this.fft.timeToFrequencyDomain(this.timeArray);
-    this.freqArrayL = this.fft.timeToFrequencyDomain(tempTimeL);
-    this.freqArrayR = this.fft.timeToFrequencyDomain(tempTimeR);
+    this.freqArrayL = this.fft.timeToFrequencyDomain(this.timeByteArraySignedL);
+    this.freqArrayR = this.fft.timeToFrequencyDomain(this.timeByteArraySignedR);
   }
 
   connectAudio (audionode) {

--- a/src/audio/audioProcessor.js
+++ b/src/audio/audioProcessor.js
@@ -54,11 +54,11 @@ export default class AudioProcessor {
 
     this.updateAudio();
   }
-
+  /* eslint-disable no-bitwise */
   updateAudio () {
     // let lastIdx = 0;
-    for (let i = 0, j=0; i < this.fftSize; i++) {
-      // Unsigned to Signed
+    for (let i = 0, j = 0; i < this.fftSize; i++) {
+      // Shift Unsigned to Signed
       this.timeArray[i] = this.timeByteArray[i] - 128;
       this.timeByteArraySignedL[i] = this.timeByteArrayL[i] - 128;
       this.timeByteArraySignedR[i] = this.timeByteArrayR[i] - 128;
@@ -67,13 +67,8 @@ export default class AudioProcessor {
       if (i & 2) { // Equivalent to i % 2
         this.timeArrayL[j] = this.timeByteArraySignedL[i];
         this.timeArrayR[j] = this.timeByteArraySignedR[i];
-        j++;
+        j += 1;
       }
-
-      // Test no smoothing
-      // tempTimeL[i] = 0.5 * (this.timeArrayL[i] + this.timeArrayL[lastIdx]);
-      // tempTimeR[i] = 0.5 * (this.timeArrayR[i] + this.timeArrayR[lastIdx]);
-      // lastIdx = i;
     }
 
     // Use full width samples for the FFT
@@ -89,4 +84,5 @@ export default class AudioProcessor {
   disconnectAudio (audionode) {
     audionode.disconnect(this.audible);
   }
+/* eslint-enable no-bitwise */
 }

--- a/src/audio/audioProcessor.js
+++ b/src/audio/audioProcessor.js
@@ -32,16 +32,18 @@ export default class AudioProcessor {
       this.splitter.connect(this.analyserL, 0);
       this.splitter.connect(this.analyserR, 1);
 
-      // New Stuff
+      // Initialised once as typed arrays
+      // Used for webaudio API raw (time domain) samples. 0 -> 255
       this.timeByteArray = new Uint8Array(this.fftSize);
       this.timeByteArrayL = new Uint8Array(this.fftSize);
       this.timeByteArrayR = new Uint8Array(this.fftSize);
 
+      // Signed raw samples shifted to -128 -> 127
       this.timeArray = new Int8Array(this.fftSize);
       this.timeByteArraySignedL = new Int8Array(this.fftSize);
       this.timeByteArraySignedR = new Int8Array(this.fftSize);
 
-
+      // Undersampled from this.fftSize to this.numSamps
       this.timeArrayL = new Int8Array(this.numSamps);
       this.timeArrayR = new Int8Array(this.numSamps);
     }
@@ -51,14 +53,18 @@ export default class AudioProcessor {
     this.analyser.getByteTimeDomainData(this.timeByteArray);
     this.analyserL.getByteTimeDomainData(this.timeByteArrayL);
     this.analyserR.getByteTimeDomainData(this.timeByteArrayR);
-
-    this.updateAudio();
+    this.processAudio();
+  }
+  updateAudio (timeByteArray, timeByteArrayL, timeByteArrayR) {
+    this.timeByteArray.set(timeByteArray);
+    this.timeByteArrayL.set(timeByteArrayL);
+    this.timeByteArrayR.set(timeByteArrayR);
+    this.processAudio();
   }
   /* eslint-disable no-bitwise */
-  updateAudio () {
-    // let lastIdx = 0;
+  processAudio () {
     for (let i = 0, j = 0; i < this.fftSize; i++) {
-      // Shift Unsigned to Signed
+      // Shift Unsigned to Signed about 0
       this.timeArray[i] = this.timeByteArray[i] - 128;
       this.timeByteArraySignedL[i] = this.timeByteArrayL[i] - 128;
       this.timeByteArraySignedR[i] = this.timeByteArrayR[i] - 128;


### PR DESCRIPTION
FFT input sample size set to analyser.fftSize = 2*numSamps = 1024 for an FFT output length of 512.

Raw sample array (Time Domain) used by milkdrop has a length of 512, however the webaudio `analyser.getByteTimeDomainData()` method will retrieve fftSize (1024) samples. Previously the back 512 bytes were dropped completely, now instead we under-sample the 1024 array to 512.

Optimisations make use of typed arrays and avoids re-declaring scoped constants, a few changes to avoid computations and assignations within 'tight' loops.