### PR TITLE
Sketch out AssemblyScript loader

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,13 @@ const config = {
         use: {
           loader: 'eslint-loader'
         },
-        enforce: 'pre'
+        enforce: "pre",
+      },
+      {
+        test: /\.ts?$/,
+        use: {
+          loader: path.resolve("loaders/assemblyscript.js"),
+        },
       },
     ]
   },

--- a/loaders/assemblyscript.js
+++ b/loaders/assemblyscript.js
@@ -1,0 +1,31 @@
+const asc = require("assemblyscript/cli/asc");
+
+module.exports = async function (content, map, meta) {
+  var callback = this.async();
+  await asc.ready;
+  const { binary, stderr } = asc.compileString(content, {});
+  if (stderr.toString()) {
+    callback(stderr.toString());
+    return;
+  }
+
+  const mod = `
+// TODO: This might be a rather inefficient way to decode.
+function decode(string) {
+  return new Uint8Array(atob(string).split("").map(function(c) {
+    return c.charCodeAt(0);
+  }));
+};
+
+var data = "${Buffer.from(binary).toString("base64")}";
+
+// TODO: If needed we could expose compiling and initializing separately. 
+// Or just expose the data itself and let the consumer compile/instantiate it.
+module.exports = function AssemblyScriptModule(options) {
+  return WebAssembly.compile(decode(data)).then(function(mod) {
+    return WebAssembly.instantiate(mod, options);
+  });
+};
+`;
+  callback(null, mod, map, meta);
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.11.6",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
+    "assemblyscript": "^0.17.11",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "eslint": "^7.9.0",

--- a/src/assemblyscript/Reset.ts
+++ b/src/assemblyscript/Reset.ts
@@ -1,0 +1,57 @@
+@external("resetPool", "warp")
+declare let warp: f64;
+@external("resetPool", "zoom")
+declare let zoom: f64;
+@external("resetPool", "zoomexp")
+declare let zoomexp: f64;
+@external("resetPool", "cx")
+declare let cx: f64;
+@external("resetPool", "cy")
+declare let cy: f64;
+@external("resetPool", "sx")
+declare let sx: f64;
+@external("resetPool", "cy")
+declare let sy: f64;
+@external("resetPool", "dx")
+declare let dx: f64;
+@external("resetPool", "dy")
+declare let dy: f64;
+@external("resetPool", "rot")
+declare let rot: f64;
+
+let warp_save: f64;
+let zoom_save: f64;
+let zoomexp_save: f64;
+let cx_save: f64;
+let cy_save: f64;
+let sx_save: f64;
+let sy_save: f64;
+let dx_save: f64;
+let dy_save: f64;
+let rot_save: f64;
+
+export function save(): void {
+  warp_save = warp;
+  zoom_save = zoom;
+  zoomexp_save = zoomexp;
+  cx_save = cx;
+  cy_save = cy;
+  sx_save = sx;
+  sy_save = sy;
+  dx_save = dx;
+  dy_save = dy;
+  rot_save = rot;
+}
+
+export function restore(): void {
+  warp = warp_save;
+  zoom = zoom_save;
+  zoomexp = zoomexp_save;
+  cx = cx_save;
+  cy = cy_save;
+  sx = sx_save;
+  sy = sy_save;
+  dx = dx_save;
+  dy = dy_save;
+  rot = rot_save;
+}

--- a/src/visualizer.js
+++ b/src/visualizer.js
@@ -2,6 +2,7 @@ import { loadModule } from "eel-wasm";
 import AudioProcessor from "./audio/audioProcessor";
 import Renderer from "./rendering/renderer";
 import Utils from "./utils";
+import loadResetMod from "./assemblyscript/Reset.ts";
 
 export default class Visualizer {
   constructor(audioContext, canvas, opts) {
@@ -462,10 +463,25 @@ export default class Visualizer {
       if (preset.pixel_eqs_str !== "") {
         preset.pixel_eqs = () => mod.exports.perPixel();
 
-        const resetMod = await Visualizer.makeResetModule(
-          wasmVarPools.perVertex,
-          ["warp", "zoom", "zoomexp", "cx", "cy", "sx", "sy", "dx", "dy", "rot"]
-        );
+        const resetMod = await loadResetMod({
+          resetPool: {
+            warp: wasmVarPools.perVertex.warp,
+            zoom: wasmVarPools.perVertex.zoom,
+            zoomexp: wasmVarPools.perVertex.zoomexp,
+            cx: wasmVarPools.perVertex.cx,
+            cy: wasmVarPools.perVertex.cy,
+            sx: wasmVarPools.perVertex.sx,
+            sy: wasmVarPools.perVertex.sy,
+            dx: wasmVarPools.perVertex.dx,
+            dy: wasmVarPools.perVertex.dy,
+            rot: wasmVarPools.perVertex.rot,
+          },
+          env: {
+            abort: () => {
+              // No idea why we need this.
+            },
+          },
+        });
 
         preset.pixel_eqs_save = () => resetMod.exports.save();
         preset.pixel_eqs_restore = () => resetMod.exports.restore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,14 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
+assemblyscript@^0.17.11:
+  version "0.17.11"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.17.11.tgz#dfc7559c26e05d6302dafc88cf2f2071f9538fe7"
+  integrity sha512-mynMSe3DOYKI2MsIdD5WSMOD8Gggt2PVVaVfVvFvpCpslJb5YMKCtcSe2pgd74+X2duHox9xg5jBgiYXjBBXTQ==
+  dependencies:
+    binaryen "98.0.0-nightly.20201109"
+    long "^4.0.0"
+
 assert@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
@@ -1285,6 +1293,11 @@ binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
+binaryen@98.0.0-nightly.20201109:
+  version "98.0.0-nightly.20201109"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-98.0.0-nightly.20201109.tgz#512bf6ca15c67bf7402144734a4836e63993aa05"
+  integrity sha512-iRarAqdH5lMWlMBzrDuJgLYJR2g4QXk93iYE2zpr6gEZkb/jCgDpPUXdhuN11Ge1zZ/6By4DwA1mmifcx7FWaw==
 
 bindings@^1.5.0:
   version "1.5.0"
@@ -2912,6 +2925,11 @@ lodash@^4.17.14, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 loose-envify@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
This hacks together a Webpack loader that can load an AssemblyScript version of the Reset module.

~~The code to get encoding/decoding to work is horrible and I'm sure there's a better/real way to do it, but I just wanted to see something working tonight.~~

While not optimally efficient, this is probably fine to land.