### PR TITLE
Make "about milkdrop" link prominent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Butterchurn
 
-Butterchurn is a WebGL implementation of the Milkdrop Visualizer
+Butterchurn is a WebGL implementation of the [Milkdrop Visualizer](http://www.geisswerks.com/about_milkdrop.html)
 
 
 ## [Try it out](https://butterchurnviz.com)


### PR DESCRIPTION
Awesome work.
I came here from [the front page of HN](https://news.ycombinator.com/item?id=26813265) which is probably atypical in the grand scheme :) but the first thing I did was tab away and search "milkdrop" and end up on wikipedia.  Consider moving the more interesting geisswerks.com link "above the fold"?

