### PR TITLE
Upgrade eel-wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@assemblyscript/loader": "^0.17.11",
     "@babel/runtime": "^7.11.2",
     "ecma-proposal-math-extensions": "0.0.2",
-    "eel-wasm": "^0.0.13"
+    "eel-wasm": "^0.0.15"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,10 +1903,10 @@ ecma-proposal-math-extensions@0.0.2:
   resolved "https://registry.yarnpkg.com/ecma-proposal-math-extensions/-/ecma-proposal-math-extensions-0.0.2.tgz#a6a3d64819db70cee0d2e1976b6315d00e4714a0"
   integrity sha1-pqPWSBnbcM7g0uGXa2MV0A5HFKA=
 
-eel-wasm@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/eel-wasm/-/eel-wasm-0.0.13.tgz#37fbeebabaa3c73f45f42ac90dc01dcec48ebf27"
-  integrity sha512-NfE8l660IbkDIm0FP51UP5rnOF5GEiXlc/RC0CzL8hmaBZ7zPqxpIBNzDtFJWhmLeQhADMck8u/Vzet9laeNsw==
+eel-wasm@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/eel-wasm/-/eel-wasm-0.0.15.tgz#d7767081e16591ca02a223c2a62cc84d304021c5"
+  integrity sha512-FSTWf6lwGn7Zc3QiV+KxWTznIqq4j9eST/aXmyN/cC39+1Arqs13YOMosHQ7tqUt+OjQmG79Vd41f9gu+w1lvA==
 
 electron-to-chromium@^1.3.523:
   version "1.3.554"


### PR DESCRIPTION
This includes a fix for a divide by zero error: https://github.com/captbaritone/eel-wasm/issues/54

Because eel-wasm ends up getting bundled into Butterchurn, it's not possible for Webamp to do this upgrade on its own, so we'll need to wait for the next Butterchurn release.

No particular hurry (it's been about a year and a half and I'm just now noticing we never shipped this fix). 

Hope you're well!